### PR TITLE
attaching id_stitcher model under each entity

### DIFF
--- a/src/tools/about.py
+++ b/src/tools/about.py
@@ -494,6 +494,7 @@ model_folders:
 
 entities:
   - name: user
+    id_stitcher: models/user_id_stitcher  # ID stitcher model reference - REQUIRED
     id_column_name: user_main_id
     id_types:
       - email
@@ -519,6 +520,7 @@ id_types:
 
 ### 2. Entities Configuration
 - Define each entity you want to track (e.g., user, account)
+- **MANDATORY**: Specify the ID stitcher model for each entity
 - Specify ID types for each entity
 - Optional: Configure feature views for different ID types
 
@@ -532,6 +534,7 @@ Add under entities to create views with specific ID types as primary keys:
 ```yaml
 entities:
   - name: user
+    id_stitcher: models/user_id_stitcher  # REQUIRED
     id_types:
       - email
       - user_id
@@ -553,6 +556,7 @@ entities:
 ```yaml
 entities:
   - name: user
+    id_stitcher: models/user_id_stitcher  # REQUIRED
     id_column_name: user_main_id
     id_types:
       - email


### PR DESCRIPTION
## Description of the change

> In the syntax samples provided, entities doesn't have any id_stitcher model mentioned. So, Added id_stitcher model_ref with each entity. Ticket [Link](https://linear.app/rudderstack/issue/PRML-1277/fix-the-missing-id-stitcher-under-entity-in-generated-pb-projectyaml).

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
