### PR TITLE
ensure entity-vars not created for id-stitcher

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -489,6 +489,10 @@ def setup_new_profiles_project(ctx: Context, project_path: str) -> dict:
     3. Creates a Python virtual environment (.venv) in the project directory.
     4. Installs the profiles-rudderstack package in the virtual environment.
     5. Installs the profiles-mlcorelib package in the virtual environment.
+    
+    **IMPORTANT NOTE**: This tool installs profiles-mlcorelib by default for compatibility.
+    However, profiles-mlcorelib is **ONLY required for propensity models**.
+    For id-stitcher and entity variables only, this dependency is not needed.
 
     **Smart Skipping**: The tool intelligently skips steps that have already been completed, such as:
     - Existing virtual environment that's working
@@ -595,8 +599,15 @@ def profiles_workflow_guide(ctx: Context,
 
     CRITICAL: This should be the FIRST tool called for any profiles-related task.
 
+    **IMPORTANT - Create Only What Customer Requests:**
+    - If customer asks for "id-stitcher only", create ONLY id-stitcher model
+    - If customer asks for "features only", create ONLY entity variables
+    - If customer asks for "propensity model", then include id-stitcher + features + propensity model
+    - NEVER assume customer wants propensity models unless explicitly requested
+    - NEVER add profiles-mlcorelib dependency unless propensity models are specifically requested
+
     Args:
-        user_goal: What you want to accomplish (e.g., "build customer profiles", "create features")
+        user_goal: What you want to accomplish (e.g., "build customer profiles", "create id-stitcher only", "create features", "create propensity model")
         current_action: What you're about to do or current step:
                        - "start" (just beginning)
                        - "knowledge_gathering" (learning about profiles concepts)

--- a/src/tools/about.py
+++ b/src/tools/about.py
@@ -235,6 +235,13 @@ your-profiles-project/
 
 ## 🚨 **CRITICAL: Common Mistakes to Avoid**
 
+### **Create Only What Customer Specifically Requests** 🎯
+- **IF** customer asks for "id-stitcher only", create **ONLY** id-stitcher model
+- **IF** customer asks for "features only", create **ONLY** entity variables  
+- **IF** customer asks for "propensity model", **THEN** include id-stitcher + features + propensity model
+- **NEVER** assume customer wants propensity models unless explicitly requested
+- **NEVER** add `profiles-mlcorelib` dependency unless propensity models are specifically requested
+
 ### **NEVER Make Up Names - Always Discover Real Data** 🚫
 - **NEVER** use generic names like "my_database.my_schema.my_table"
 - **NEVER** use generic names like "my_snowflake_connection"
@@ -330,7 +337,10 @@ source .venv/bin/activate
 
 # Install required packages
 pip install profiles-rudderstack
-pip install profiles-mlcorelib>=0.8.1
+
+# IMPORTANT: Install profiles-mlcorelib ONLY if using propensity models
+# For id-stitcher and feature engineering only, mlcorelib is NOT required
+pip install profiles-mlcorelib>=0.8.1  # Only for propensity models
 ```
 
 ### 2. Initialize Profiles Builder CLI
@@ -761,6 +771,12 @@ Profiles helps you create unified customer views by:
 1. Stitching multiple identifiers into a single identity
 2. Generating customer features from various data sources
 
+**IMPORTANT - Create Only What Customer Requests:**
+- **ID-Stitcher Only**: If customer asks for "id-stitcher only", create ONLY the id_stitcher model configuration
+- **Features Only**: If customer asks for "entity variables" or "features only", create ONLY var_groups with entity_vars
+- **Complete Profiles**: If customer asks for "customer profiles" or "unified views", create both id_stitcher and entity_vars
+- **Propensity Models**: Only create propensity models when explicitly requested (requires id_stitcher + entity_vars + propensity model)
+
 ## Prerequisites
 Before configuring models.yaml:
 1. Use about_profiles(topic="project") to understand the project structure and entities.
@@ -1069,15 +1085,17 @@ Using Profile's Propensity Scores Data App, you can predict the likelihood of us
 
 ## Prerequisites
 - An active RudderStack Profiles project (v0.18.0 or above) using Snowflake, BigQuery, or Redshift
-- Install the profiles-mlcorelib library: `pip install profiles-mlcorelib`
+- **ONLY FOR PROPENSITY MODELS**: Install the profiles-mlcorelib library: `pip install profiles-mlcorelib`
 - Python requirements:
   - Redshift/BigQuery: Python 3.9.0 to 3.11.10
   - Snowflake: Python ≥ 3.9.0 and < 3.11.0
-- Update pb_project.yaml to include:
+- **ONLY FOR PROPENSITY MODELS**: Update pb_project.yaml to include:
 ```yaml
 python_requirements:
-  - profiles_mlcorelib>=0.8.1
+  - profiles_mlcorelib>=0.8.1  # Only required for propensity models
 ```
+
+**IMPORTANT**: `profiles-mlcorelib` is **NOT required** for standard profiles projects that only use id-stitcher and entity variables. Only add this dependency when explicitly creating propensity models.
 
 ## Project Setup Steps
 

--- a/src/tools/profiles.py
+++ b/src/tools/profiles.py
@@ -337,12 +337,18 @@ class ProfilesTools:
     def setup_new_profiles_project(self, project_path: str) -> dict:
         """
         Sets up a new profiles project in the specified directory using pip and venv.
+        
+        **IMPORTANT**: This method installs profiles-mlcorelib by default for compatibility.
+        However, profiles-mlcorelib is **ONLY required for propensity models**.
+        For id-stitcher and entity variables only, this dependency is not needed.
+        
         Steps:
         1. Ensure the project directory exists.
         2. Verify Python 3.10 is installed.
         3. Create a Python virtual environment.
         4. Install the profiles-rudderstack package using pip.
-        5. Return a status dict with messages and errors.
+        5. Install profiles-mlcorelib (note: only needed for propensity models).
+        6. Return a status dict with messages and errors.
         """
         messages = []
         errors = []
@@ -566,8 +572,15 @@ For more information, refer to the RudderStack Profiles documentation.
 
         CRITICAL: This should be the FIRST tool called for any profiles-related task.
 
+        **IMPORTANT - Create Only What Customer Requests:**
+        - If customer asks for "id-stitcher only", create ONLY id-stitcher model
+        - If customer asks for "features only", create ONLY entity variables
+        - If customer asks for "propensity model", then include id-stitcher + features + propensity model
+        - NEVER assume customer wants propensity models unless explicitly requested
+        - NEVER add profiles-mlcorelib dependency unless propensity models are specifically requested
+
         Args:
-            user_goal: What you want to accomplish (e.g., "build customer profiles", "create features")
+            user_goal: What you want to accomplish (e.g., "build customer profiles", "create id-stitcher only", "create features", "create propensity model")
             current_action: What you're about to do or current step:
                            - "start" (just beginning)
                            - "knowledge_gathering" (learning about profiles concepts)
@@ -917,6 +930,8 @@ For more information, refer to the RudderStack Profiles documentation.
         """Get base critical warnings that apply to all workflow actions."""
         return [
             f"🚨 CRITICAL: Current year is {current_year}, NOT 2024!",
+            "🚨 CREATE ONLY WHAT CUSTOMER REQUESTS: If they ask for 'id-stitcher only', do NOT create entity-vars or propensity models",
+            "🚨 MLCORELIB DEPENDENCY: Only add profiles-mlcorelib if customer specifically requests propensity models",
             "🚨 MANDATORY: Call about_profiles(topic='inputs'), about_profiles(topic='models'), about_profiles(topic='macros') BEFORE creating any YAML",
             "🚨 NEVER add WHERE clauses with dates in YAML to filter old data from all input tabels - use --begin_time flag. This is different from where clause in entity-vars, which is acceptable while using timestamp macros",
             "🚨 NEVER assume column names exist - always use describe_table() first",


### PR DESCRIPTION
## Description of the change

> When asked to create a id-stitcher model, It was trying to create entity-vars/propensity models as well. So, I have added few instructions to restrain that. Ticket [link](https://linear.app/rudderstack/issue/PRML-1274/update-mcp-docstrings-to-ensure-it-doesnt-create-entity-varspropensity).

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
